### PR TITLE
fix: add default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
     }


### PR DESCRIPTION
The `svelte` field is a [legacy field](https://svelte.dev/docs/kit/packaging#Anatomy-of-a-package.json-svelte). With the latest version of vite and vitest, it didn't recognize the export when it was just `svelte`. Adding the default export got it to be recognized.

The error before this was this:
```
Error: Failed to resolve entry for package "@portabletext/svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "svelte-media-queries" package
```